### PR TITLE
Fix CI some more

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,6 @@
 name: Main workflow
 
-on: [pull_request, push]
+on: pull_request
 
 jobs:
   plugin_test:
@@ -14,6 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Ensure rustup-init is installed
+        run: |
+            mkdir -p ~/bin
+            curl https://sh.rustup.rs -sSf > ~/bin/rustup-init
+            echo ~/bin >> $GITHUB_PATH
+
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ check-format:
 
 .PHONY: lint
 lint:
-	shellcheck --source-path=SCRIPTDIR $(SH_SRCFILES)
+	shellcheck $(SH_SRCFILES)

--- a/bin/install
+++ b/bin/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck source=./exec-env
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "$0")/exec-env"
 export PATH="$CARGO_HOME/bin:$ASDF_INSTALL_PATH/bin:$PATH"
 

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck source=./exec-env
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "$0")/exec-env"
 
 # From https://unix.stackexchange.com/a/269303

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck source=./exec-env
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "$0")/exec-env"
 export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/bin/post-plugin-add
+++ b/bin/post-plugin-add
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck source=./exec-env
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "$0")/exec-env"
 export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/bin/post-plugin-add
+++ b/bin/post-plugin-add
@@ -4,6 +4,11 @@
 source "$(dirname "$0")/exec-env"
 export PATH="$CARGO_HOME/bin:$PATH"
 
+if ! type rustup-init &>/dev/null; then
+    echo "You must install rustup-init before adding this plugin"
+    exit 1
+fi
+
 rustup-init -y --no-modify-path --profile="${ASDF_RUST_PROFILE:-default}"
 
 if type -P cargo | grep -q "^/usr"; then

--- a/bin/post-plugin-update
+++ b/bin/post-plugin-update
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck source=./exec-env
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "$0")/exec-env"
 export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/bin/pre-plugin-remove
+++ b/bin/pre-plugin-remove
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck source=./exec-env
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "$0")/exec-env"
 export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck source=./exec-env
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "$0")/exec-env"
 export PATH="$CARGO_HOME/bin:$PATH"
 

--- a/lib/commands/command-rustup.bash
+++ b/lib/commands/command-rustup.bash
@@ -2,7 +2,7 @@
 
 ASDF_PLUGIN_PATH="${ASDF_PLUGIN_PATH:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &>/dev/null && pwd)"}"
 
-# shellcheck source=../../bin/exec-env
+# shellcheck source=SCRIPTDIR/../../bin/exec-env
 source "$ASDF_PLUGIN_PATH/bin/exec-env"
 export PATH="$CARGO_HOME/bin:$PATH"
 


### PR DESCRIPTION
For `shellcheck`, instead of using a command line flag for resolving dynamic sourcing, this uses inline directives. This means that `make lint` and CI do the same thing.

For the actual test, make sure `rustup-init` is installed.